### PR TITLE
Load direct cdot image in email, not from S3/Cloudfront cache

### DIFF
--- a/app/models/cdot_camera/camera_view.rb
+++ b/app/models/cdot_camera/camera_view.rb
@@ -21,6 +21,10 @@ module CdotCamera
       end
       s3_image.url
     end
+
+    def cdot_image_path
+      "http://i.cotrip.org/" + image_location
+    end
   end
 
 end

--- a/app/views/cdot_camera/cameras/_newsletter_show.erb
+++ b/app/views/cdot_camera/cameras/_newsletter_show.erb
@@ -5,10 +5,7 @@
       <div style="text-align: center;">
         <% camera.camera_views.each do |view| %>
           <div style="float: left; width: 31%; margin: 0 1.1%;">
-            <%= image_tag view.s3_image_fetch_url, style: "width: 100%; max-height: 186px;" %>
-            <% if defined? view.s3_image_updated_at.to_ago %>
-              <div style="color: #999999; font-size: smaller; margin-bottom: 3px;">Updated: <%= view.s3_image_updated_at.ap_style_dates("%A, %B %e, %Y %l:%M %p") %></div>
-            <% end %>
+            <%= image_tag view.cdot_image_path, style: "width: 100%; max-height: 186px;" %>
             <div style="margin-bottom: 3px;"><%= view.description %></div>
             <div style="color: #999999; font-size: smaller; margin-bottom: 3px;"><%= view.source %></div>
           </div>

--- a/lib/cdot_camera/version.rb
+++ b/lib/cdot_camera/version.rb
@@ -1,3 +1,3 @@
 module CdotCamera
-  VERSION = '0.1.11'
+  VERSION = '0.1.12'
 end


### PR DESCRIPTION
Hoping that the image will load more reliably if our server doesn't have to upload it to S3 and serve through Cloudfront first.